### PR TITLE
Perl 5.18 からPerlIO::scalarでopenできるのがバイト列だけになるため

### DIFF
--- a/lib/WWW/BBS/2ch/Thread.pm
+++ b/lib/WWW/BBS/2ch/Thread.pm
@@ -1,6 +1,7 @@
 package WWW::BBS::2ch::Thread;
 use strict;
 use warnings;
+use Encode ();
 use WWW::BBS::2ch::Res;
 use Class::Accessor::Lite rw => [ qw(api url title content res_list) ];
 
@@ -40,7 +41,7 @@ sub parse {
     $self->res_list([]);
 
     my $no = 1;
-    open my $fh, '<:utf8', \$self->content;
+    open my $fh, '<:utf8', \Encode::encode_utf8($self->content);
     while (<$fh>) {
         chomp;
         next unless defined $_ && length $_;

--- a/t/03_thread.t
+++ b/t/03_thread.t
@@ -6,6 +6,7 @@ use WWW::BBS::2ch;
 
 subtest 'Strings with code points over 0xFF may not be mapped into in-memory file handles' => sub {
     plan skip_all => 'version is less then 5.18' if $^V lt v5.18.0;
+    plan skip_all => 'set TEST_LIVE to run this test' unless $ENV{TEST_LIVE};
 
     my $bbs = WWW::BBS::2ch->new;
     my $board = $bbs->get_board('http://headline.2ch.net/bbynamazu/');

--- a/t/03_thread.t
+++ b/t/03_thread.t
@@ -1,0 +1,20 @@
+use strict;
+use warnings;
+use utf8;
+use Test::More;
+use WWW::BBS::2ch;
+
+subtest 'Strings with code points over 0xFF may not be mapped into in-memory file handles' => sub {
+    plan skip_all => 'version is less then 5.18' if $^V lt v5.18.0;
+
+    my $bbs = WWW::BBS::2ch->new;
+    my $board = $bbs->get_board('http://headline.2ch.net/bbynamazu/');
+    $board->update;
+    my $thread = $board->thread_list->[0];
+    $thread->update;
+    $thread->parse;
+
+    cmp_ok @{ $thread->res_list }, '>', 0, 'res_list > 0';
+};
+
+done_testing;


### PR DESCRIPTION
refs.
http://d.hatena.ne.jp/gfx/20130426/1366947365
http://tsucchi.github.io/perl/2013/04/27/capture-stdin/
